### PR TITLE
Zod changes

### DIFF
--- a/src/vendors/zod.ts
+++ b/src/vendors/zod.ts
@@ -8,9 +8,31 @@ export default async function getToJsonSchemaFn(): Promise<ToJsonSchemaFn> {
 
     // https://zod.dev/library-authors?id=how-to-support-zod-and-zod-mini-simultaneously#how-to-support-zod-3-and-zod-4-simultaneously
     if ("_zod" in (schema as $ZodType | ZodTypeAny)) {
-      handler = await tryImport(import("zod/v4/core"), "zod v4").then(
-        (mod) => mod.toJSONSchema as ToJsonSchemaFn,
-      );
+      const toJSONSchema = await tryImport(
+        import("zod/v4/core"),
+        "zod v4",
+      ).then((mod) => mod.toJSONSchema);
+
+      // Add flatten override function
+      // TODO (kingbri): Unsure how the override should be handled
+      // So for now, use this as the default unless the user specifies otherwise
+      const createJsonSchema = (
+        schema: $ZodType,
+        options?: Record<string, unknown>,
+      ) =>
+        toJSONSchema(schema, {
+          override: (ctx) => {
+            // Flattens nested allOfs with intersections
+            if (ctx.jsonSchema.allOf) {
+              ctx.jsonSchema.allOf = ctx.jsonSchema.allOf.flatMap((schema) =>
+                schema.allOf ? schema.allOf : [schema],
+              );
+            }
+          },
+          ...(options ?? {}),
+        });
+
+      handler = createJsonSchema as ToJsonSchemaFn;
     } else {
       handler = await tryImport(import("zod-to-json-schema"), "zod v3").then(
         (mod) => mod.zodToJsonSchema as ToJsonSchemaFn,


### PR DESCRIPTION
Adds Zod override to help flatten edge cases and prevent errors as requested in #6 

There are a couple of changes that can be done that I'd like to discuss:
1. Where should the override go? If the user specifies an override, the default one is ignored and can cause user error
2. Should this be present in standard-json? Maybe standard-openapi is a better fit. However, zod-specific variables such as `ctx` will not be present when calling an untyped generic function.