### PR TITLE
[suggestion] move quansync to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,13 +84,15 @@
       }
     }
   },
+  "dependencies": {
+    "quansync": "^0.2.11"
+  },
   "peerDependencies": {
     "@standard-schema/spec": "^1.0.0",
     "@types/json-schema": "^7.0.15",
     "@valibot/to-json-schema": "^1.3.0",
     "arktype": "^2.1.20",
     "effect": "^3.16.8",
-    "quansync": "^0.2.11",
     "valibot": "^1.1.0",
     "zod": "^3.25.0 || ^4.0.0",
     "zod-to-json-schema": "^3.24.5"


### PR DESCRIPTION
I don't think quansync should be declared in peerDependencies.

On most package managers (depending on configs and/or versions), it won't probably be installed by default and require explicit addition.

Quansync seems to be part of regular deps and used in handlers.ts independently of the validation library used.

I'm also wondering if it might make sense to use Promise.try (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try)

That will depend on how pkgroll transpiles the code... Don't really know about that